### PR TITLE
Faster cc_sea(): switched terra:extract to terra:relate

### DIFF
--- a/R/cc_outl.R
+++ b/R/cc_outl.R
@@ -199,6 +199,13 @@ cc_outl <- function(x,
                            area = terra::expanse(ref))
         area <- area[!is.na(area$area), ]
         area <- area[!is.na(area$country), ]
+
+        ## naturalearth uses -99 for missing values?
+        area <- area[area$country != "-99", ]
+
+        ## CN-TW (Taiwan) doesn't map to a country in the GBIF database:
+        ## naturalearth dataset uses CN-TW for Taiwan, GBIF uses TW.
+        area[area$country == "CN-TW", "country"] <- "TW"
         
         # get number of records in GBIF per country as proxy for sampling intensity
         nrec <- vapply(area$country, 

--- a/R/cc_sea.R
+++ b/R/cc_sea.R
@@ -137,7 +137,8 @@ cc_sea <- function(x,
     ## have to make sure they are the same and in this case they already are
     ## -----
     ## point-in-polygon test
-    ext_dat <- terra::extract(ref, pts)
+    ##ext_dat <- terra::extract(ref, pts)
+    ext_dat <- relate(pts, ref, "intersects", pairs = TRUE, na.rm = FALSE)
     out <- !is.na(ext_dat[!duplicated(ext_dat[, 1]), 2])
     out <- data.frame(terra::geom(pts)[, c("x", "y"), drop = FALSE], out)
     colnames(out)[1:2] <- c(lon, lat)
@@ -154,7 +155,8 @@ cc_sea <- function(x,
     
     # select relevant columns
     #point in polygon test
-    ext_dat <- terra::extract(ref, pts)
+    ext_dat <- relate(pts, ref, "intersects", pairs = TRUE, na.rm = FALSE)
+    ##ext_dat <- terra::extract(ref, pts)
     out <- !is.na(ext_dat[!duplicated(ext_dat[, 1]), 2])
   }
   

--- a/R/cc_sea.R
+++ b/R/cc_sea.R
@@ -138,7 +138,8 @@ cc_sea <- function(x,
     ## -----
     ## point-in-polygon test
     ##ext_dat <- terra::extract(ref, pts)
-    ext_dat <- relate(pts, ref, "intersects", pairs = TRUE, na.rm = FALSE)
+    ext_dat <- terra::relate(pts, ref, "intersects", pairs = TRUE,
+                             na.rm = FALSE)
     out <- !is.na(ext_dat[!duplicated(ext_dat[, 1]), 2])
     out <- data.frame(terra::geom(pts)[, c("x", "y"), drop = FALSE], out)
     colnames(out)[1:2] <- c(lon, lat)
@@ -155,7 +156,8 @@ cc_sea <- function(x,
     
     # select relevant columns
     #point in polygon test
-    ext_dat <- relate(pts, ref, "intersects", pairs = TRUE, na.rm = FALSE)
+    ext_dat <- terra::relate(pts, ref, "intersects", pairs = TRUE,
+                             na.rm = FALSE) 
     ##ext_dat <- terra::extract(ref, pts)
     out <- !is.na(ext_dat[!duplicated(ext_dat[, 1]), 2])
   }


### PR DESCRIPTION
In my tests this decreased the processing time for 10K records from 94 seconds to < 1 second. I didn't look too carefully at the logic in that function, after determining that it was the call to terra:extract that was taking up all the time, and terra:relate could be made to accomplish the same thing in a tiny fraction of the time.

I ran your tests and everything came back fine (except for an unrelated issue with cc_outl and Taiwan?).

```R
data(buffland)
buffland <- unwrap(buffland)
crs(buffland) <- '+proj=longlat +datum=WGS84 +no_defs'

x <- data.frame(decimalLongitude = runif(10000, -180, 180), 
                decimalLatitude = runif(10000, -90, 90))

cleaned <- cc_sea(x, ref = buffland)
```